### PR TITLE
Add bg on news page and fix title alignments

### DIFF
--- a/src/Pages/Homepage/sections/styled.tsx
+++ b/src/Pages/Homepage/sections/styled.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import BackgroundImage from "assets/background/GrowthBG.png";
 import BGLanding from "assets/background/BGLanding.png";
 import LandingLogo from "assets/background/LandingLogo.png";
+import bgimage from "assets/background/bgpartner2@4x.png";
 // Sections
 
 const SectionContainer = styled.div<{ height?: string }>`
@@ -19,8 +20,13 @@ export const HomeContainer = styled(SectionContainer)`
   background-position: center top;
 `;
 export const EcoContainer = styled(SectionContainer)`
-  background-color: ${({ theme }) => theme.addOnColors.background2};
-  padding: 24px;
+    height: 100%;
+  width: 100%;
+  background-image: url(${bgimage});
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+
 `;
 
 export const GrowthContainer = styled(SectionContainer)`

--- a/src/Pages/Partners/partners.tsx
+++ b/src/Pages/Partners/partners.tsx
@@ -28,7 +28,7 @@ const Partners = () => {
     <>
       <Page>
         <BgPage>
-          <div style={{ position: "relative", zIndex: 2 }}>
+          <div style={{ position: "relative", zIndex: 2, paddingTop: 100, }}>
             <PageTitle size="xxl" color="#fdda00">
               Partners
             </PageTitle>

--- a/src/Pages/Roadmap/roadmap.tsx
+++ b/src/Pages/Roadmap/roadmap.tsx
@@ -27,7 +27,7 @@ const Roadmap = () => {
     <>
       <Page>
         <BgPage>
-          <div style={{position: 'relative', zIndex: 2}}>
+          <div style={{position: 'relative', zIndex: 2, paddingTop: 100,}}>
             <HeadingGlow size='xxl' color='#fdda00' >ROADMAP</HeadingGlow>
             <NavOptionContainer
               alignItems="center"

--- a/src/Pages/Team/Teams.tsx
+++ b/src/Pages/Team/Teams.tsx
@@ -15,7 +15,7 @@ const TeamsPage: React.FC = () => {
   return (
     <Page>
       <BgPage>
-        <div style={{ position: "relative", zIndex: 2 }}>
+        <div style={{ position: "relative", zIndex: 2, paddingTop: 90, }}>
           <HeaderContainer>
             <PageTitle> MGG TEAM AND ADVISORS </PageTitle>
             <Text as="p">

--- a/src/Pages/Whitepaper/styled.tsx
+++ b/src/Pages/Whitepaper/styled.tsx
@@ -48,7 +48,7 @@ export const PageTitle = styled(Heading)`
   color: ${({theme}) => theme.colors.primary};
   font-size: 3.2em;
   border: 2px solid yellow; /* Yellow border */
-  padding: 37px; 
+  padding: 28px; 
   display: inline-block;
   box-shadow: 0 0 10px yellow; /* Glow effect */
   border-radius: 15px;


### PR DESCRIPTION
Added BG for news page 
![image](https://github.com/user-attachments/assets/0c5d47df-10b5-4f15-b58b-abc048b554c7)

Fix spaces on top of page titles
![image](https://github.com/user-attachments/assets/243a892b-ecc4-4b0d-bb5c-29ffbaa4d309)
![image](https://github.com/user-attachments/assets/6dfa1589-67e9-408f-b304-b6b883d251c2)
![image](https://github.com/user-attachments/assets/f5e9a041-0ab3-4ee8-a908-c86fa54b119b)
